### PR TITLE
Fix/Update Redis-rs dependencies 0.17=>0.21.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,12 @@ deser-hjson = "0.1.13"
 env_logger = "0.5.13"
 lazy_static = "1.4"
 log = "0.4"
-redis = "0.17"
+redis = "0.21.2"
 regex = "1.5"
 reqwest = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_regex = "1.1"
 thiserror = "1.0"
-
 [patch.crates-io]
 # deser-hjson = { path = "../deser-hjson" }


### PR DESCRIPTION
the old dependencies version was requiring futures:0.3 but wasn't adding it automatically/explicitely
the new version of redis-rs does it.